### PR TITLE
Add Dockerfile for easy launch support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.git*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# To use this with Docker:
+# 1. `docker build -t iftttdelay .`
+# 2. `docker run -p 3002:3002 -d iftttdelay`
+# The service will now be listening on http://localhost:3002
+
+FROM node:10.11-alpine
+
+EXPOSE 3002
+
+WORKDIR /usr/src/app
+
+# Install packages
+COPY package*.json ./
+RUN npm install
+
+# Copy application source into container
+COPY . .
+
+# Run as a non-root user for better security
+USER node
+
+CMD [ "/usr/src/app/bin/www" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # To use this with Docker:
 # 1. `docker build -t iftttdelay .`
-# 2. `docker run -p 3002:3002 -d iftttdelay`
+# 2. `docker run -p 3002:3002 -d --init iftttdelay`
 # The service will now be listening on http://localhost:3002
 
 FROM node:10.11-alpine


### PR DESCRIPTION
Uses the standard node docker container and runs as non-root for better security. Can be easily mapped to listen on different ports, eg: `docker run -p 8080:3002 -d iftttdelay`