### PR TITLE
Issue2 error on large delay times

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ Enjoy! And let me know if you have questions.
 
 ## API
 
-* `delay?event={EVENT}&t={DELAY_IN_MINUTES}&key={IFTTT_KEY}&reset={0,1}`: trigger the IFTTT `event` with the given `key`, after `t` minutes. If `reset` is set to 1, all existing timers of the given key and event will be canceled, and a new timer will be created with the given parameters. That is, it "resets" the timer.
+* `delay?event={EVENT}&t={DELAY_IN_MINUTES}&key={IFTTT_KEY}&reset={0,1}`: trigger the IFTTT `event` with the given `key`, after `t` minutes, limited to 35791 minutes. Decimal values are supported. If `reset` is set to 1, all existing timers of the given key and event will be canceled, and a new timer will be created with the given parameters. That is, it "resets" the timer.
 * `cancel?event={EVENT}&key={IFTTT_KEY}`: cancel all the existing timers of the given `key` and `event`.

--- a/app.js
+++ b/app.js
@@ -64,6 +64,15 @@ app.use('/delay', function(req, res) {
         res.send("Error: must specify t (for delay time) and key and event in the URL.");
         return;
     }
+    var maxSupportedDelay = Math.pow(2,31) - 1;
+    if ((delay * 60 * 1000) > maxSupportedDelay) {
+        // setTimeout() uses a 32-bit signed integer for its delay parameter
+        // A larger number causes setTimeout() to execute immediately, which
+        // is likely not what the user would want.
+        // Throw an explicit error if the passed delay time will exceed it.
+        res.send("Error: Delay time cannot exceed " + (maxSupportedDelay / 60 / 1000) + " minutes.");
+        return;
+    }
     
     // Fetch the values from the POST body
     var value1 = req.body.Value1;


### PR DESCRIPTION
Fix issue #2 by throwing an error if the provided delay time would exceed a 32-bit integer when converted to ms.  Maximum supported time is a dedicated variable and could easily be set to an artificial limit instead of a calculated one.  (I do question how long we can assume the IFTTTDelay server to really stay up. A (much) smaller value seems valid.)  Also updated the documentation.