### PR TITLE
fix: upgrade fastify to 5.8.5 to resolve validation bypass CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@fastify/formbody": "^8.0.2",
-        "fastify": "^5.7.3",
+        "fastify": "^5.8.5",
         "suncalc": "^1.9.0",
         "undici": "^6.15.0"
       },
@@ -1692,9 +1692,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fastify": {
-      "version": "5.8.4",
-      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.4.tgz",
-      "integrity": "sha512-sa42J1xylbBAYUWALSBoyXKPDUvM3OoNOibIefA+Oha57FryXKKCZarA1iDntOCWp3O35voZLuDg2mdODXtPzQ==",
+      "version": "5.8.5",
+      "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.8.5.tgz",
+      "integrity": "sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@fastify/formbody": "^8.0.2",
-    "fastify": "^5.7.3",
+    "fastify": "^5.8.5",
     "suncalc": "^1.9.0",
     "undici": "^6.15.0"
   },


### PR DESCRIPTION
## Summary
- upgrade fastify from ^5.7.3 to ^5.8.5 to clear CVE-2026-25223 and CVE-2026-33806
- refresh package-lock.json so the resolved fastify package moves from 5.8.4 to 5.8.5
- keep the change scoped to dependency metadata only, with no application code changes

## Verification
- npm test
- npm run build
- npm audit
- npm start and GET /