### PR TITLE
fix: upgrade fast-uri to 3.1.2 to resolve CVE-2026-6321 and CVE-2026-6322

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1676,9 +1676,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -26,5 +26,8 @@
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",
     "vitest": "^4.0.18"
+  },
+  "overrides": {
+    "fast-uri": "3.1.2"
   }
 }


### PR DESCRIPTION
## Summary

- Upgrade `fast-uri` from 3.1.0 to 3.1.2 via `overrides` in `package.json`
- Fixes two high-severity advisories:
  - **CVE-2026-6321**: Path traversal via percent-encoded dot segments (`%2E`, `%2F`)
  - **CVE-2026-6322**: Host confusion via percent-encoded authority delimiters (`%40`, `%3A`)

## Verification

- All 10 tests pass
- `npm audit` no longer reports fast-uri vulnerabilities
- Patch bump only (3.1.0 → 3.1.2), fully backward compatible