### PR TITLE
fix: upgrade supertest to resolve qs advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/suncalc": "^1.9.2",
         "@types/supertest": "^6.0.3",
         "rollup": ">=4.59.0",
-        "supertest": "^6.3.4",
+        "supertest": "^7.2.2",
         "ts-node": "^10.9.2",
         "tsx": "^4.19.2",
         "typescript": "^5.7.3",
@@ -1783,6 +1783,16 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
     "node_modules/cookiejar": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
@@ -1796,6 +1806,24 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -2156,16 +2184,18 @@
       }
     },
     "node_modules/formidable": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
-      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@paralleldrive/cuid2": "^2.2.2",
         "dezalgo": "^1.0.4",
-        "once": "^1.4.0",
-        "qs": "^6.11.0"
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "funding": {
         "url": "https://ko-fi.com/tunnckoCore/commissions"
@@ -2887,9 +2917,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3123,14 +3153,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3233,59 +3263,39 @@
       "integrity": "sha512-vMJ8Byp1uIPoj+wb9c1AdK4jpkSKVAywgHX0lqY7zt6+EWRRC3Z+0Ucfjy/0yxTVO1hwwchZe4uoFNqrIC24+A=="
     },
     "node_modules/superagent": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
-      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
-      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "component-emitter": "^1.3.0",
+        "component-emitter": "^1.3.1",
         "cookiejar": "^2.1.4",
-        "debug": "^4.3.4",
+        "debug": "^4.3.7",
         "fast-safe-stringify": "^2.1.1",
-        "form-data": "^4.0.0",
-        "formidable": "^2.1.2",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
         "methods": "^1.1.2",
         "mime": "2.6.0",
-        "qs": "^6.11.0",
-        "semver": "^7.3.8"
+        "qs": "^6.14.1"
       },
       "engines": {
-        "node": ">=6.4.0 <13 || >=14"
-      }
-    },
-    "node_modules/superagent/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supertest": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
-      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
-      "deprecated": "Please upgrade to supertest v7.1.3+, see release notes at https://github.com/forwardemail/supertest/releases/tag/v7.1.3 - maintenance is supported by Forward Email @ https://forwardemail.net",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "cookie-signature": "^1.2.2",
         "methods": "^1.1.2",
-        "superagent": "^8.1.2"
+        "superagent": "^10.3.0"
       },
       "engines": {
-        "node": ">=6.4.0"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/thread-stream": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@types/suncalc": "^1.9.2",
     "@types/supertest": "^6.0.3",
     "rollup": ">=4.59.0",
-    "supertest": "^6.3.4",
+    "supertest": "^7.2.2",
     "ts-node": "^10.9.2",
     "tsx": "^4.19.2",
     "typescript": "^5.7.3",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { configDefaults, defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    exclude: [...configDefaults.exclude, "dist/**"],
+  },
+});


### PR DESCRIPTION
## Summary
- Upgrade Supertest from 6.3.4 to 7.2.2, pulling in Superagent 10.3.0 and qs 6.15.2.
- Add a Vitest config to exclude generated dist output so tests remain stable after running the TypeScript build.

## Verification
- npm run build
- npm test
- npm audit --json reports 0 vulnerabilities.